### PR TITLE
Renaming `qsat` with `saturation_water_vapor_mixing_ratio_wrt_moist_air`

### DIFF
--- a/testinput_tier_1/vader/gauss_state_F12.nc
+++ b/testinput_tier_1/vader/gauss_state_F12.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e408dc61f367265055b7cb2e7b1ed57985d532608d4d999a7218f20339729d83
-size 23303760
+oid sha256:d66038c99a8eaa1e21bb5998da684bf7ecf0bcfebc813f7c496afa05a0c65b1c
+size 23303808


### PR DESCRIPTION
## Description

This PR renames `qsat` with `saturation_water_vapor_mixing_ratio_wrt_moist_air` inside VADER unit test file.

This is the difference on the header of the files (old vs. new):

```
$ diff old.txt new.txt
31c31
< 	nz_qsat = 70 ;
---
> 	nz_saturation_water_vapor_mixing_ratio_wrt_moist_air = 70 ;
100,101c100,101
< 	double qsat(nz_qsat, ny, nx) ;
< 		qsat:_FillValue = -3.33476705790481e+38 ;
---
> 	double saturation_water_vapor_mixing_ratio_wrt_moist_air(nz_saturation_water_vapor_mixing_ratio_wrt_moist_air, ny, nx) ;
> 		saturation_water_vapor_mixing_ratio_wrt_moist_air:_FillValue = -3.33476705790481e+38 ;
```

## Issue(s) addressed

Resolves TO-BE-CREATED

## Dependencies

- [ ] https://github.com/JCSDA-internal/vader/pull/327
- [ ] https://github.com/JCSDA-internal/jedi-model-data/pull/10

## Impact

None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
