### PR TITLE
Rename skin_temperature to skin_temperature_at_surface

### DIFF
--- a/testinput_tier_1/vader/gauss_state_F12.nc
+++ b/testinput_tier_1/vader/gauss_state_F12.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d233899233525dedcd862bdff69ff0bd1bd9a7a4690a9b14a101538ed958f40
-size 43048086
+oid sha256:3536d5a92b22dcf37b06248e426ed5d4afe35c05b9033be98a45b25c43cfdded
+size 43049795

--- a/testinput_tier_1/vader/gauss_state_F12.nc
+++ b/testinput_tier_1/vader/gauss_state_F12.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30d8806e1259a33acf3fd70e5a494bdccdc3f747a8671eb27013f369f13a4418
-size 43046947
+oid sha256:6d233899233525dedcd862bdff69ff0bd1bd9a7a4690a9b14a101538ed958f40
+size 43048086

--- a/testinput_tier_1/vader/gauss_state_F12.nc
+++ b/testinput_tier_1/vader/gauss_state_F12.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3536d5a92b22dcf37b06248e426ed5d4afe35c05b9033be98a45b25c43cfdded
-size 43049795
+oid sha256:15e8df1597fee3233bd2d847c46a851d7c1725e38d63bff2b727217e35e12a94
+size 43051635


### PR DESCRIPTION
## Description

Rename variable:

- `skin_temperature` to `skin_temperature_at_surface`

in `gauss_state_F12.nc`

## Issue(s) addressed

Required for https://github.com/JCSDA-internal/vader/pull/382


