### PR TITLE
add namelist file used by saber::mgbf

### DIFF
--- a/testinput_tier_1/saber/dirac_mgbf.nml
+++ b/testinput_tier_1/saber/dirac_mgbf.nml
@@ -1,0 +1,16 @@
+&PARAMETERS_MGBETA
+  mg_ampl01=2.5,mg_ampl02=2.5,mg_ampl03=2.0,
+  mg_weig1=20.,mg_weig2=20.,mg_weig3=15000.,mg_weig4=1.,
+  hx=6,hy=6,hz=12,p=2,
+  mgbf_line=.true., mgbf_proc=5,
+  lm_a=65,lm=32,km2=0,km3=3,
+  coef_normalization_const=2.831
+  nxPE=2,nyPE=2,im_filt=24,jm_filt=24,
+  nm0 = 48,
+  mm0 = 48,
+  l_vertical_filter=.true.,
+  gm_max=2,
+  l_for_localization=.true.,
+  ldelta=.false.,
+/
+


### PR DESCRIPTION
This PR is to add a namelist file to be used by saber::mgbf as in https://github.com/JCSDA-internal/saber/pull/1227.